### PR TITLE
subMenu for tabs

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -213,6 +213,7 @@ components:
         - id
         - title
         - type
+        - icon
       properties:
         id:
            type: string

--- a/api.yaml
+++ b/api.yaml
@@ -37,10 +37,25 @@ paths:
                         - $ref: '#/components/schemas/tabDefinitionMenuView'
                         - $ref: '#/components/schemas/tabDefinitionStoryView'
               example: {tabs: [
-                {id: homepage, title: Start, type: webView},
-                {id: news, title: Schlagzeilen, type: cpView},
+                {id: start, title: Start, type: cpView, subMenu: [
+                  {id: homepage, title: Aktuell, type: menuEntryWeb, url: "https://www.zeit.de/index"},
+                  {id: ressortPolitik, title: Politik, type: menuEntryNative, cpItem: {id: "{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}"} },
+                  {id: ressortGesellschaft, title: Gesellschaft, type: menuEntryNative, cpItem: {id: "{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}"} },
+                  {id: ressortWirtschaft, title: Wirtschaft, type: menuEntryNative, cpItem: {id: "{urn:uuid:ea13ef02-74f3-4010-8cd7-777327fb881a}"} },
+                  {id: ressortWissen, title: Wissen, type: menuEntryNative, cpItem: {id: "{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}"} },
+                  {id: ressortKultur, title: Kultur, type: menuEntryNative, cpItem: {id: "{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}"} }
+                ]},
+                {id: news, title: Schlagzeilen, type: cpView, subMenu: [
+                  {id: newsAll, title: "Alle Schlagzeilen", type: menuEntryNative, cpItem: {id: "{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}"} },
+                  {id: newsMostImportant, title: "Die wichtigsten Nachrichten", type: menuEntryNative, cpItem: {id: "{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}"} },
+                  {id: newsAnalysisAndReports, title: "Analysen und Hintergründe", type: menuEntryNative, cpItem: {id: "{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}"} }
+                ]},
                 {id: discover, title: Entdecken, type: storyView},
-                {id: zplus, title: Mein Abo, type: cpView},
+                {id: zplus, title: Mein Abo, type: cpView, subMenu: [
+                  {id: exclusive, title: "Exklusive Artikel", type: menuEntryNative, cpItem: {id: "{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}"} },
+                  {id: zeitPDFWebReader, title: "DIE ZEIT", type: menuEntryWeb, url: "https://epaper.zeit.de/abo/diezeit" },
+                  {id: wochenMarkt, title: "Wochenmarkt", type: menuEntryWeb, url: "https://www.zeit.de/wochenmarkt" }
+                ]},
                 {id: menu, title: Mehr, type: menuView, sections: [
                   {id: user-menu, title: "Mein Bereich", entries: [
                     {id: reading-list, title: Merkliste, type: menuEntryNative, targetId: native-reading-list},
@@ -259,15 +274,6 @@ components:
           type: string
           enum:
             - "storyView"
-    cpItem:
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          format: uuid
-          example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
-      example: {id: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"}
     menuSection:
       properties:
         id:
@@ -301,19 +307,21 @@ components:
     menuEntryNative:
       allOf:
         - $ref: '#/components/schemas/menuEntryBase'
-        - required:
-          - targetId
         - properties:
             targetId:
               type: string
               example: "some-native-id"
             type: 
               example: "menuEntryNative"
-            cpSelection:
-              type: array
-              items:
-                oneOf:
-                  - $ref: '#/components/schemas/cpItem'
+            cpItem:
+              required:
+                - id
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
+              example: {id: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"}
     menuEntryWeb:
       allOf:
         - $ref: '#/components/schemas/menuEntryBase'

--- a/api.yaml
+++ b/api.yaml
@@ -186,6 +186,13 @@ components:
            minLength: 1
            maxLength: 80
            example: "A Title"
+        subMenu:
+          type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/menuEntryNative'
+              - $ref: '#/components/schemas/menuEntryWeb'
+              - $ref: '#/components/schemas/menuEntryBrowser'          
     tabDefinitionCpView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
@@ -219,8 +226,7 @@ components:
     tabDefinitionMenuView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
-        - properties:
-            
+        - properties:            
             sections:
               type: array
               items:

--- a/api.yaml
+++ b/api.yaml
@@ -37,7 +37,7 @@ paths:
                         - $ref: '#/components/schemas/tabDefinitionMenuView'
                         - $ref: '#/components/schemas/tabDefinitionStoryView'
               example: {tabs: [
-                {id: start, title: Start, type: cpView, subMenu: [
+                {id: start, title: Start, type: cpView, icon: iconHouse, subMenu: [
                   {id: homepage, title: Aktuell, type: menuEntryWeb, url: "https://www.zeit.de/index"},
                   {id: ressortPolitik, title: Politik, type: menuEntryNative, cpItem: {id: "{urn:uuid:b4d1e3b1-aac4-4a80-b820-e4093fe24a36}"} },
                   {id: ressortGesellschaft, title: Gesellschaft, type: menuEntryNative, cpItem: {id: "{urn:uuid:c92ad9be-67e0-497d-beee-6c2e063352cc}"} },
@@ -45,18 +45,18 @@ paths:
                   {id: ressortWissen, title: Wissen, type: menuEntryNative, cpItem: {id: "{urn:uuid:c84692ca-b0c9-4772-8c6b-85e2abc446e1}"} },
                   {id: ressortKultur, title: Kultur, type: menuEntryNative, cpItem: {id: "{urn:uuid:49b109f0-bbad-495e-8a88-ad91ec1ef8f9}"} }
                 ]},
-                {id: news, title: Schlagzeilen, type: cpView, subMenu: [
+                {id: news, title: Schlagzeilen, type: cpView, icon: iconClock, subMenu: [
                   {id: newsAll, title: "Alle Schlagzeilen", type: menuEntryNative, cpItem: {id: "{urn:uuid:08945d5e-483c-4e7b-9843-69a8f590ada9}"} },
                   {id: newsMostImportant, title: "Die wichtigsten Nachrichten", type: menuEntryNative, cpItem: {id: "{urn:uuid:df60a52c-5f4d-4804-833d-ec31e24dbd43}"} },
                   {id: newsAnalysisAndReports, title: "Analysen und Hintergründe", type: menuEntryNative, cpItem: {id: "{urn:uuid:d6913463-1804-466d-b6d0-34376ef21916}"} }
                 ]},
-                {id: discover, title: Entdecken, type: storyView},
-                {id: zplus, title: Mein Abo, type: cpView, subMenu: [
+                {id: discover, title: Entdecken, type: storyView, icon: iconCompass},
+                {id: zplus, title: Mein Abo, type: cpView, icon: iconZPlus, subMenu: [
                   {id: exclusive, title: "Exklusive Artikel", type: menuEntryNative, cpItem: {id: "{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}"} },
                   {id: zeitPDFWebReader, title: "DIE ZEIT", type: menuEntryWeb, url: "https://epaper.zeit.de/abo/diezeit" },
                   {id: wochenMarkt, title: "Wochenmarkt", type: menuEntryWeb, url: "https://www.zeit.de/wochenmarkt" }
                 ]},
-                {id: menu, title: Mehr, type: menuView, sections: [
+                {id: menu, title: Mehr, type: menuView, icon: iconAvatar, sections: [
                   {id: user-menu, title: "Mein Bereich", entries: [
                     {id: reading-list, title: Merkliste, type: menuEntryNative, targetId: native-reading-list},
                     {id: reading-history, title: Verlauf, type: menuEntryNative, targetId: native-reading-history},
@@ -221,14 +221,11 @@ components:
         title:
            type: string
            minLength: 1
-           maxLength: 80
-           example: "A Title"
-        subMenu:
-          type: array
-          items:
-            oneOf:
-              - $ref: '#/components/schemas/menuEntryNative'
-              - $ref: '#/components/schemas/menuEntryWeb'        
+           maxLength: 15
+           example: "Start"
+        icon:
+          type: string
+          example: iconHome        
     tabDefinitionCpView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
@@ -240,6 +237,12 @@ components:
               enum:
                - cpView
               example: "cpView"
+            subMenu:
+              type: array
+              items:
+                oneOf:
+                  - $ref: '#/components/schemas/menuEntryNative'
+                  - $ref: '#/components/schemas/menuEntryWeb'
     tabDefinitionWebView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
@@ -253,6 +256,12 @@ components:
               format: uri
               type: string
               example: "https://www.zeit.de/index"
+            subMenu:
+              type: array
+              items:
+                oneOf:
+                  - $ref: '#/components/schemas/menuEntryNative'
+                  - $ref: '#/components/schemas/menuEntryWeb'
     tabDefinitionMenuView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'

--- a/api.yaml
+++ b/api.yaml
@@ -211,23 +211,18 @@ components:
           items:
             oneOf:
               - $ref: '#/components/schemas/menuEntryNative'
-              - $ref: '#/components/schemas/menuEntryWeb'
-              - $ref: '#/components/schemas/menuEntryBrowser'          
+              - $ref: '#/components/schemas/menuEntryWeb'        
     tabDefinitionCpView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
         - required:
-            - cpSelection
+            - subMenu
         - properties:
             type:
               type: string
               enum:
                - cpView
               example: "cpView"
-            cpSelection:
-              type: array
-              items:
-                $ref: '#/components/schemas/cpItem'
     tabDefinitionWebView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
@@ -237,10 +232,6 @@ components:
               enum:
                - webView
               example: "webView"
-            url: 
-              type: string
-              format: uri
-              example: "https://www.zeit.de/index"
     tabDefinitionMenuView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
@@ -254,19 +245,23 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/menuSection'
-    tabDefinitionNativeOnlyView:
+    tabDefinitionStoryView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
       required:
-        - viewID
+        - targetId
       properties:
         type:
           type: string
           enum:
-            - "nativeOnlyView"
+            - "storyView"
         viewID:
           type: string
           example: "discover-view"
+        cpSelection:
+          type: array
+          items:
+            $ref: '#/components/schemas/cpItem'
     cpItem:
       required:
         - uuid

--- a/api.yaml
+++ b/api.yaml
@@ -35,17 +35,19 @@ paths:
                         - $ref: '#/components/schemas/tabDefinitionCpView'
                         - $ref: '#/components/schemas/tabDefinitionWebView'
                         - $ref: '#/components/schemas/tabDefinitionMenuView'
-                        - $ref: '#/components/schemas/tabDefinitionNativeOnlyView'
+                        - $ref: '#/components/schemas/tabDefinitionStoryView'
               example: {tabs: [
-                {id: homepage, title: Start, type: webView, url: "https://www.zeit.de/index"},
-                {id: news, title: Schlagzeilen, type: cpView, cpSelection: [{id: '{urn:uuid:c8ae2aa4-ff88-4ed5-9c09-56fd00f89eb5}'}]},
-                {id: discover, title: Entdecken, type: nativeOnlyView, viewID: discover-view},
-                {id: zplus, title: Mein Abo, type: cpView, cpSelection: [{id: '{urn:uuid:0fd9480f-1b52-4fcb-942e-8089e378102e}'}]},
-                {id: menu, title: Mehr, type: menuView, sections: [{id: user-menu, entries: [
-                  {id: reading-list, title: Merkliste, type: menuEntryNative, targetId: native-reading-list},
-                  {id: reading-history, title: Verlauf, type: menuEntryNative, targetId: native-reading-history},
-                  {id: comment-list, title: Kommentare, type: menuEntryWeb, url: "https://profile.zeit.de"}
-                ]}]}
+                {id: homepage, title: Start, type: webView},
+                {id: news, title: Schlagzeilen, type: cpView},
+                {id: discover, title: Entdecken, type: storyView},
+                {id: zplus, title: Mein Abo, type: cpView},
+                {id: menu, title: Mehr, type: menuView, sections: [
+                  {id: user-menu, title: "Mein Bereich", entries: [
+                    {id: reading-list, title: Merkliste, type: menuEntryNative, targetId: native-reading-list},
+                    {id: reading-history, title: Verlauf, type: menuEntryNative, targetId: native-reading-history},
+                    {id: comment-list, title: Kommentare, type: menuEntryWeb, url: "https://profile.zeit.de"}
+                  ]}
+                ]}
               ]}
          "503":
            description: "Server Timeout"
@@ -232,6 +234,10 @@ components:
               enum:
                - webView
               example: "webView"
+            url:
+              format: uri
+              type: string
+              example: "https://www.zeit.de/index"
     tabDefinitionMenuView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
@@ -248,28 +254,20 @@ components:
     tabDefinitionStoryView:
       allOf:
         - $ref: '#/components/schemas/tabDefinitionBase'
-      required:
-        - targetId
       properties:
         type:
           type: string
           enum:
             - "storyView"
-        viewID:
-          type: string
-          example: "discover-view"
-        cpSelection:
-          type: array
-          items:
-            $ref: '#/components/schemas/cpItem'
     cpItem:
       required:
-        - uuid
+        - id
       properties:
         id:
           type: string
           format: uuid
           example: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"
+      example: {id: "{urn:uuid:d995ba5a-a7fb-401a-bdc8-86cf2cbf0cda}"}
     menuSection:
       properties:
         id:
@@ -311,6 +309,11 @@ components:
               example: "some-native-id"
             type: 
               example: "menuEntryNative"
+            cpSelection:
+              type: array
+              items:
+                oneOf:
+                  - $ref: '#/components/schemas/cpItem'
     menuEntryWeb:
       allOf:
         - $ref: '#/components/schemas/menuEntryBase'
@@ -319,6 +322,7 @@ components:
         - properties:
             url:
               type: string
+              format: uri
               example: "https://www.zeit.de/some/webviewurl"
             type: 
               example: "menuEntryWeb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.31.1.tgz",
-      "integrity": "sha512-+IuIxXX8grZcDVLaC12WCGy62iHJ2v8kTptU4H4EgY/ue6tKeMu/jzIAs+pLFOuYwfG4+VQ+CrC9UeHR9oNKBw=="
+      "version": "3.32.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.32.5.tgz",
+      "integrity": "sha512-3SKHv8UVqsKKknivtACHbFDGcn297jkoZN2h6zAZ7b2yoaJNMaRadQpC3qFw3GobZTGzqHCgHph4ZH9NkaCjrQ=="
     }
   }
 }


### PR DESCRIPTION
Mit Prepublic habe ich besprochen, dass die Tabs in der Regel ein subMenu-Array haben und der erste Eintrag dieses Menüs initial geladen wird. 
* Ich habe das subMenu als property des tabDefinitionBase eingeführt
* Ich habe die tabDefinitionNativeOnly in tabDefinitionStory umbenannt. Sie ist für Tabs vorgesehen, in denen wir eine instagram-artige Story zeigen, aber kein subMenu.
* Die subMenus habe ich für alle Tabs mit echten Titeln und uuids in die examples konfiguriert.
* Die cpSelection war bisher ein Array mit cpItems. Jetzt gibt es die cpSelectuon nicht mehr, sondern nur noch pro menuEntryNative eine cpItem. Darin steckt die uuid, mit der die App Content von der cp-API holen kann.