### PR TITLE
MAINT: Define and apply a (hopefully consistent) YAML coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# @see: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Global styles
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# YAML
+[*.yaml]
+indent_size = 2
+
+# Markdown
+[*.md]
+trim_trailing_whitespace = false
+
+# make
+[Makefile]
+indent_style = tab

--- a/api.yaml
+++ b/api.yaml
@@ -26,7 +26,7 @@ paths:
   /structure:
     get:
        tags:
-         - "structure"
+         - structure
        summary: "Returns tab and menu/submenu configuration for the app UI"
        responses:
          "200":

--- a/api.yaml
+++ b/api.yaml
@@ -41,10 +41,10 @@ paths:
                     type: array
                     items:
                       oneOf:
-                        - $ref: "#/components/schemas/tabDefinitionCpView"
-                        - $ref: "#/components/schemas/tabDefinitionWebView"
-                        - $ref: "#/components/schemas/tabDefinitionMenuView"
-                        - $ref: "#/components/schemas/tabDefinitionStoryView"
+                        - $ref: "#/components/schemas/TabDefinitionCpView"
+                        - $ref: "#/components/schemas/TabDefinitionWebView"
+                        - $ref: "#/components/schemas/TabDefinitionMenuView"
+                        - $ref: "#/components/schemas/TabDefinitionStoryView"
               example: {tabs: [
                 {id: start, title: Start, type: cpView, icon: iconHouse, subMenu: [
                   {id: homepage, title: Aktuell, type: menuEntryWeb, url: "https://www.zeit.de/index"},
@@ -316,7 +316,7 @@ components:
                   - $ref: "#/components/schemas/CenterpageModuleWeb"
 
 
-    tabDefinitionBase:
+    TabDefinitionBase:
       required:
         - id
         - title
@@ -342,9 +342,9 @@ components:
         icon:
           type: string
           example: iconHome
-    tabDefinitionCpView:
+    TabDefinitionCpView:
       allOf:
-        - $ref: "#/components/schemas/tabDefinitionBase"
+        - $ref: "#/components/schemas/TabDefinitionBase"
         - required:
             - subMenu
           properties:
@@ -357,11 +357,11 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/menuEntryNative"
-                  - $ref: "#/components/schemas/menuEntryWeb"
-    tabDefinitionWebView:
+                  - $ref: "#/components/schemas/MenuEntryNative"
+                  - $ref: "#/components/schemas/MenuEntryWeb"
+    TabDefinitionWebView:
       allOf:
-        - $ref: "#/components/schemas/tabDefinitionBase"
+        - $ref: "#/components/schemas/TabDefinitionBase"
         - properties:
             type:
               type: string
@@ -376,11 +376,11 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: "#/components/schemas/menuEntryNative"
-                  - $ref: "#/components/schemas/menuEntryWeb"
-    tabDefinitionMenuView:
+                  - $ref: "#/components/schemas/MenuEntryNative"
+                  - $ref: "#/components/schemas/MenuEntryWeb"
+    TabDefinitionMenuView:
       allOf:
-        - $ref: "#/components/schemas/tabDefinitionBase"
+        - $ref: "#/components/schemas/TabDefinitionBase"
         - properties:
             type:
               type: string
@@ -390,10 +390,10 @@ components:
             sections:
               type: array
               items:
-                $ref: "#/components/schemas/menuSection"
-    tabDefinitionStoryView:
+                $ref: "#/components/schemas/MenuSection"
+    TabDefinitionStoryView:
       allOf:
-        - $ref: "#/components/schemas/tabDefinitionBase"
+        - $ref: "#/components/schemas/TabDefinitionBase"
       properties:
         type:
           type: string
@@ -402,7 +402,7 @@ components:
           example: "storyView"
 
 
-    menuSection:
+    MenuSection:
       properties:
         id:
           type: string
@@ -411,10 +411,10 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: "#/components/schemas/menuEntryNative"
-              - $ref: "#/components/schemas/menuEntryWeb"
-              - $ref: "#/components/schemas/menuEntryBrowser"
-    menuEntryBase:
+              - $ref: "#/components/schemas/MenuEntryNative"
+              - $ref: "#/components/schemas/MenuEntryWeb"
+              - $ref: "#/components/schemas/MenuEntryBrowser"
+    MenuEntryBase:
       required:
         - id
         - title
@@ -432,9 +432,9 @@ components:
             - menuEntryNative
             - menuEntryWeb
             - menuEntryBrowser
-    menuEntryNative:
+    MenuEntryNative:
       allOf:
-        - $ref: "#/components/schemas/menuEntryBase"
+        - $ref: "#/components/schemas/MenuEntryBase"
         - properties:
             targetId:
               type: string
@@ -443,16 +443,16 @@ components:
               type: string
               enum:
                 - menuEntryNative
-              example: "menuEntryNative"
+              example: "MenuEntryNative"
             cpItem:
               required:
                 - id
               properties:
                 id:
                   $ref: "#/components/schemas/uuid"
-    menuEntryWeb:
+    MenuEntryWeb:
       allOf:
-        - $ref: "#/components/schemas/menuEntryBase"
+        - $ref: "#/components/schemas/MenuEntryBase"
         - required:
             - url
           properties:
@@ -465,9 +465,9 @@ components:
               enum:
                 - menuEntryWeb
               example: "menuEntryWeb"
-    menuEntryBrowser:
+    MenuEntryBrowser:
       allOf:
-        - $ref: "#/components/schemas/menuEntryBase"
+        - $ref: "#/components/schemas/MenuEntryBase"
         - required:
             - url
           properties:
@@ -478,7 +478,7 @@ components:
               type: string
               enum:
                 - menuEntryBrowser
-              example: "menuEntryBrowser"
+              example: "MenuEntryBrowser"
 
 
   securitySchemes:

--- a/api.yaml
+++ b/api.yaml
@@ -443,7 +443,7 @@ components:
               type: string
               enum:
                 - menuEntryNative
-              example: "MenuEntryNative"
+              example: "menuEntryNative"
             cpItem:
               required:
                 - id
@@ -478,7 +478,7 @@ components:
               type: string
               enum:
                 - menuEntryBrowser
-              example: "MenuEntryBrowser"
+              example: "menuEntryBrowser"
 
 
   securitySchemes:

--- a/api.yaml
+++ b/api.yaml
@@ -25,15 +25,15 @@ paths:
 
   /structure:
     get:
-       tags:
-         - structure
-       summary: "Returns tab and menu/submenu configuration for the app UI"
-       responses:
-         "200":
-           # XXX description is required, but really already exists in ..summary
-           description: "Success"
-           content:
-             application/json:
+      tags:
+        - structure
+      summary: "Returns tab and menu/submenu configuration for the app UI"
+      responses:
+        "200":
+          # XXX description is required, but really already exists in ..summary
+          description: "Success"
+          content:
+            application/json:
               schema:
                 type: object
                 properties:
@@ -89,10 +89,10 @@ paths:
         - cp
       summary: "Returns the teasers (i.e. content references) on a CenterPage"
       responses:
-         "200":
-           description: "Success"
-           content:
-             application/json:
+        "200":
+          description: "Success"
+          content:
+            application/json:
               schema:
                 type: object
                 properties:
@@ -107,8 +107,8 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/CenterpageRegion"
-         "404":
-           description: "No centerpage found for the given uuid"
+        "404":
+          description: "No centerpage found for the given uuid"
 
 
 components:
@@ -324,14 +324,14 @@ components:
         - icon
       properties:
         id:
-           type: string
-           description: "ID of the tab"
-           example: "justsomeuniquestring"
+          type: string
+          description: "ID of the tab"
+          example: "justsomeuniquestring"
         title:
-           type: string
-           minLength: 1
-           maxLength: 15
-           example: "Start"
+          type: string
+          minLength: 1
+          maxLength: 15
+          example: "Start"
         type:
           type: string
           enum:
@@ -385,7 +385,7 @@ components:
             type:
               type: string
               enum:
-                 - menuView
+                - menuView
               example: "menuView"
             sections:
               type: array

--- a/api.yaml
+++ b/api.yaml
@@ -41,10 +41,10 @@ paths:
                     type: array
                     items:
                       oneOf:
-                        - $ref: '#/components/schemas/tabDefinitionCpView'
-                        - $ref: '#/components/schemas/tabDefinitionWebView'
-                        - $ref: '#/components/schemas/tabDefinitionMenuView'
-                        - $ref: '#/components/schemas/tabDefinitionStoryView'
+                        - $ref: "#/components/schemas/tabDefinitionCpView"
+                        - $ref: "#/components/schemas/tabDefinitionWebView"
+                        - $ref: "#/components/schemas/tabDefinitionMenuView"
+                        - $ref: "#/components/schemas/tabDefinitionStoryView"
               example: {tabs: [
                 {id: start, title: Start, type: cpView, icon: iconHouse, subMenu: [
                   {id: homepage, title: Aktuell, type: menuEntryWeb, url: "https://www.zeit.de/index"},
@@ -106,7 +106,7 @@ paths:
                   items:
                     type: array
                     items:
-                      $ref: '#/components/schemas/CenterpageRegion'
+                      $ref: "#/components/schemas/CenterpageRegion"
          "404":
            description: "No centerpage found for the given uuid"
 
@@ -298,7 +298,7 @@ components:
             items:
               type: array
               items:
-                $ref: '#/components/schemas/CenterpageArea'
+                $ref: "#/components/schemas/CenterpageArea"
     CenterpageArea:
       allOf:
         - $ref: "#/components/schemas/CenterpageAreaBase"
@@ -312,8 +312,8 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/CenterpageModuleTeaser'
-                  - $ref: '#/components/schemas/CenterpageModuleWeb'
+                  - $ref: "#/components/schemas/CenterpageModuleTeaser"
+                  - $ref: "#/components/schemas/CenterpageModuleWeb"
 
 
     tabDefinitionBase:
@@ -344,7 +344,7 @@ components:
           example: iconHome
     tabDefinitionCpView:
       allOf:
-        - $ref: '#/components/schemas/tabDefinitionBase'
+        - $ref: "#/components/schemas/tabDefinitionBase"
         - required:
             - subMenu
           properties:
@@ -357,11 +357,11 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/menuEntryNative'
-                  - $ref: '#/components/schemas/menuEntryWeb'
+                  - $ref: "#/components/schemas/menuEntryNative"
+                  - $ref: "#/components/schemas/menuEntryWeb"
     tabDefinitionWebView:
       allOf:
-        - $ref: '#/components/schemas/tabDefinitionBase'
+        - $ref: "#/components/schemas/tabDefinitionBase"
         - properties:
             type:
               type: string
@@ -376,11 +376,11 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/menuEntryNative'
-                  - $ref: '#/components/schemas/menuEntryWeb'
+                  - $ref: "#/components/schemas/menuEntryNative"
+                  - $ref: "#/components/schemas/menuEntryWeb"
     tabDefinitionMenuView:
       allOf:
-        - $ref: '#/components/schemas/tabDefinitionBase'
+        - $ref: "#/components/schemas/tabDefinitionBase"
         - properties:
             type:
               type: string
@@ -390,10 +390,10 @@ components:
             sections:
               type: array
               items:
-                $ref: '#/components/schemas/menuSection'
+                $ref: "#/components/schemas/menuSection"
     tabDefinitionStoryView:
       allOf:
-        - $ref: '#/components/schemas/tabDefinitionBase'
+        - $ref: "#/components/schemas/tabDefinitionBase"
       properties:
         type:
           type: string
@@ -411,9 +411,9 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/menuEntryNative'
-              - $ref: '#/components/schemas/menuEntryWeb'
-              - $ref: '#/components/schemas/menuEntryBrowser'
+              - $ref: "#/components/schemas/menuEntryNative"
+              - $ref: "#/components/schemas/menuEntryWeb"
+              - $ref: "#/components/schemas/menuEntryBrowser"
     menuEntryBase:
       required:
         - id
@@ -434,7 +434,7 @@ components:
             - menuEntryBrowser
     menuEntryNative:
       allOf:
-        - $ref: '#/components/schemas/menuEntryBase'
+        - $ref: "#/components/schemas/menuEntryBase"
         - properties:
             targetId:
               type: string
@@ -452,7 +452,7 @@ components:
                   $ref: "#/components/schemas/uuid"
     menuEntryWeb:
       allOf:
-        - $ref: '#/components/schemas/menuEntryBase'
+        - $ref: "#/components/schemas/menuEntryBase"
         - required:
             - url
           properties:
@@ -467,7 +467,7 @@ components:
               example: "menuEntryWeb"
     menuEntryBrowser:
       allOf:
-        - $ref: '#/components/schemas/menuEntryBase'
+        - $ref: "#/components/schemas/menuEntryBase"
         - required:
             - url
           properties:

--- a/api.yaml
+++ b/api.yaml
@@ -127,10 +127,10 @@ components:
     cp_element_type:
       type: string
       enum:
-      - region
-      - area
-      - teaser
-      - web
+        - region
+        - area
+        - teaser
+        - web
       description: "Type of the cp element"
 
     CenterpageElement:
@@ -156,7 +156,7 @@ components:
             type:
               type: string
               enum:
-               - teaser
+                - teaser
               example: "teaser"
             layout:
               type: string
@@ -256,7 +256,7 @@ components:
             type:
               type: string
               enum:
-               - web
+                - web
               example: "web"
             raw_content:
               type: string
@@ -293,7 +293,7 @@ components:
             type:
               type: string
               enum:
-               - region
+                - region
               example: "region"
             items:
               type: array
@@ -306,7 +306,7 @@ components:
             type:
               type: string
               enum:
-               - area
+                - area
               example: "area"
             items:
               type: array
@@ -335,10 +335,10 @@ components:
         type:
           type: string
           enum:
-           - cpView
-           - webView
-           - menuView
-           - storyView
+            - cpView
+            - webView
+            - menuView
+            - storyView
         icon:
           type: string
           example: iconHome
@@ -351,7 +351,7 @@ components:
             type:
               type: string
               enum:
-               - cpView
+                - cpView
               example: "cpView"
             subMenu:
               type: array
@@ -366,7 +366,7 @@ components:
             type:
               type: string
               enum:
-               - webView
+                - webView
               example: "webView"
             url:
               # format: uri
@@ -385,7 +385,7 @@ components:
             type:
               type: string
               enum:
-               - menuView
+                 - menuView
               example: "menuView"
             sections:
               type: array
@@ -442,7 +442,7 @@ components:
             type:
               type: string
               enum:
-               - menuEntryNative
+                - menuEntryNative
               example: "menuEntryNative"
             cpItem:
               required:
@@ -463,7 +463,7 @@ components:
             type:
               type: string
               enum:
-               - menuEntryWeb
+                - menuEntryWeb
               example: "menuEntryWeb"
     menuEntryBrowser:
       allOf:
@@ -477,7 +477,7 @@ components:
             type:
               type: string
               enum:
-               - menuEntryBrowser
+                - menuEntryBrowser
               example: "menuEntryBrowser"
 
 

--- a/api.yaml
+++ b/api.yaml
@@ -196,7 +196,7 @@ components:
                 ratio:
                   type: number
                   example: 1.7778
-                mobileRatio: # optional
+                mobile_ratio: # optional
                   type: number
                   example: 1.3333
             dateFirstPublished:

--- a/codingstyle.rst
+++ b/codingstyle.rst
@@ -1,0 +1,23 @@
+=================
+YAML Coding-Style
+=================
+
+Syntax
+======
+
+* Indentation: 2 Leerzeichen
+  (Listen immer einrücken, auch wenn der yaml-Standard es dort nicht zwingend verlangt)
+* Strings quoten mit Double Quotes (``"foobar"``, NICHT ``'foobar'``)
+* Identifier nicht quoten (``type: string``, NICHT ``type: "string"``)
+* Leerzeilen zwischen inhaltlichen Abschnitten verwenden
+* Inline Listen/Dicts höchstens bei Beispielen verwenden (z.B. ``example: ["zplus"]``), sonst immer neue Zeile und einrücken
+
+
+Namen
+=====
+
+* Schema-Objekte verwenden CamelCase mit Großbuchstaben vorn
+  (z.B. ``CenterpageElement``, ``TabDefinitionBase``)
+* Properties verwenden Snake-Case und werden klein geschrieben
+  (z.B. ``base_url``, ``date_first_published``)
+  XXX mit Prepublic absprechen

--- a/index.rst
+++ b/index.rst
@@ -7,6 +7,7 @@ App-API
 
     overview
     onboarding
+    codingstyle
     operations
 
 * `API <./swagger.html>`_


### PR DESCRIPTION
# YAML Coding-Style

## Syntax

* Indentation: 2 Leerzeichen
  (Listen immer einrücken, auch wenn der yaml-Standard es dort nicht zwingend verlangt)
* Strings quoten mit Double Quotes (``"foobar"``, NICHT ``'foobar'``)
* Identifier nicht quoten (``type: string``, NICHT ``type: "string"``)
* Leerzeilen zwischen inhaltlichen Abschnitten verwenden
* Inline Listen/Dicts höchstens bei Beispielen verwenden (z.B. ``example: ["zplus"]``), sonst immer neue Zeile und einrücken


## Namen

* Schema-Objekte verwenden CamelCase mit Großbuchstaben vorn
  (z.B. ``CenterpageElement``, ``TabDefinitionBase``)
* Properties verwenden Snake-Case und werden klein geschrieben
  (z.B. ``base_url``, ``date_first_published``)
  - [ ]  mit Prepublic absprechen